### PR TITLE
msbuild: improve assets copy for WordPress

### DIFF
--- a/wordpress/PeachPied.WordPress.msbuildproj
+++ b/wordpress/PeachPied.WordPress.msbuildproj
@@ -12,10 +12,11 @@
     <Description>WordPress project transformed to managed .NET Standard library.</Description>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="**/*.php" Exclude="wp-config-sample.php;wp-content/plugins/hello.php" />
-    <Content Include="**" Exclude="obj/**;bin/**;wp-content/uploads/**;**/*.php;*.msbuildproj">
+    <Compile Include="**/*.php" Exclude="wp-config-sample.php;wp-content/uploads/**;wp-content/plugins/hello.php;wp-content/plugins/akismet/**" />
+    <Content Include="**" Exclude="obj/**;bin/**;wp-content/uploads/**;**/*.php;wp-content/plugins/akismet/**;*.msbuildproj" CopyToOutputDirectory="PreserveNewest">
       <PackagePath>contentFiles/any/netcoreapp2.0/wordpress/</PackagePath>
       <PackageCopyToOutput>true</PackageCopyToOutput>
+      <Link>wordpress\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Content>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Added akismet to excluded compile
Added akismet to excluded assets copy
Added `CopyToOutput="PreserveNewest"` attribute to `<Content>` block
Added `<link>` configuration to ensure the WordPress assets appear under `wordpress/...`