### PR TITLE
app.csproj: Remove version: AspNetCore dependency

### DIFF
--- a/app/app.csproj
+++ b/app/app.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Resolves the following error from the toolchain:

```plain
Error: A PackageReference to 'Microsoft.AspNetCore.All' specified a Version of `2.1.4`. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs
```

Signed-off-by: Daniel Llewellyn <daniel@bowlhat.net>