### PR TITLE
Microsoft SQL Server Support

### DIFF
--- a/PeachPied.WordPress.AspNetCore/RequestDelegateExtension.cs
+++ b/PeachPied.WordPress.AspNetCore/RequestDelegateExtension.cs
@@ -108,6 +108,15 @@ namespace PeachPied.WordPress.AspNetCore
             ctx.DefineConstant("LOGGED_IN_SALT", (PhpValue)config.SALT.LOGGED_IN_SALT);
             ctx.DefineConstant("NONCE_SALT", (PhpValue)config.SALT.NONCE_SALT);
 
+            // Additional constants
+            if (config.Constants != null)
+            {
+                foreach (var pair in config.Constants)
+                {
+                    ctx.DefineConstant(pair.Key, pair.Value);
+                }
+            }
+
             // disable wp_cron() during the request, we have our own scheduler to fire the job
             ctx.DefineConstant("DISABLE_WP_CRON", PhpValue.True);   // define('DISABLE_WP_CRON', true);
 

--- a/PeachPied.WordPress.AspNetCore/WordPressConfig.cs
+++ b/PeachPied.WordPress.AspNetCore/WordPressConfig.cs
@@ -70,6 +70,11 @@ namespace PeachPied.WordPress.AspNetCore
         /// </summary>
         public SaltData SALT { get; private set; } = new SaltData();
 
+        /// <summary>
+        /// Additional PHP constants to be set before each request starts.
+        /// </summary>
+        public Dictionary<string, string> Constants { get; set; }
+
         // 
 
         /// <summary>


### PR DESCRIPTION
Please make possible to WordPress.NET support Microsoft SQL Server beside MySQL for database.