### PR TITLE
Bump PeachPie to 0.9.46; revert rest-api.php fix

### DIFF
--- a/build/Settings.props
+++ b/build/Settings.props
@@ -6,7 +6,7 @@
     <!-- common version -->
     <VersionPrefix Condition=" '$(VersionPrefix)'=='' ">1.0.0</VersionPrefix>
     
-    <PeachpieVersion>0.9.45</PeachpieVersion>
+    <PeachpieVersion>0.9.46</PeachpieVersion>
     <WordPressVersion>5.2.3</WordPressVersion>
 
     <!-- metadata generation -->

--- a/wordpress/PeachPied.WordPress.msbuildproj
+++ b/wordpress/PeachPied.WordPress.msbuildproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Peachpie.NET.Sdk/0.9.45">
+﻿<Project Sdk="Peachpie.NET.Sdk/0.9.46">
   <Import Project="..\build\Settings.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>0e51d101-0992-4aa6-a134-26ea3f2e3934</ProjectGuid>

--- a/wordpress/wp-includes/rest-api.php
+++ b/wordpress/wp-includes/rest-api.php
@@ -73,15 +73,14 @@ function register_rest_route( $namespace, $route, $args = array(), $override = f
 		'callback' => null,
 		'args'     => array(),
 	);
-	foreach ( $args as $key => $arg ) {
+	foreach ( $args as $key => &$arg_group ) {
 		if ( ! is_numeric( $key ) ) {
 			// Route option, skip here.
 			continue;
 		}
 
-		$args[$key] = array_merge( $defaults, $arg ); // WPDOTNET // CHANGED: &$arg_group on .NET caused persistent aliased value causing problems in further enumeration and lazy copying
-		// $arg_group         = array_merge( $defaults, $arg_group );
-		// $arg_group['args'] = array_merge( $common_args, $arg_group['args'] );
+		$arg_group         = array_merge( $defaults, $arg_group );
+		$arg_group['args'] = array_merge( $common_args, $arg_group['args'] );
 	}
 
 	$full_route = '/' . trim( $namespace, '/' ) . '/' . trim( $route, '/' );


### PR DESCRIPTION
Now that PP 0.9.46 includes fixes for iolevel/peachpie#345 we can
revert our hack in wp-includes/rest-api.php.

Signed-off-by: Daniel Llewellyn <daniel@bowlhat.net>