### PR TITLE
Dev/issue106

### DIFF
--- a/app/Program.cs
+++ b/app/Program.cs
@@ -34,6 +34,8 @@ namespace peachserver
             services.AddWordPress(options =>
             {
                 //
+                options.SiteUrl = "http://localhost:5004/wordpress";
+                options.HomeUrl = "http://localhost:5004";
             });
         }
 

--- a/app/Program.cs
+++ b/app/Program.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.AspNetCore.Http;
 
 namespace peachserver
 {
@@ -35,8 +34,6 @@ namespace peachserver
             services.AddWordPress(options =>
             {
                 //
-                options.SiteUrl = "http://localhost:5004/wordpress"; // Where the wordpress resides
-                options.HomeUrl = "http://localhost:5004"; // What url has the client site
             });
         }
 
@@ -52,15 +49,7 @@ namespace peachserver
             // using empty set of .NET plugins
             app.UseWordPress();
 
-            app.UseRouting();
-            app.UseEndpoints(endpoints =>
-            {
-
-                endpoints.MapGet("/", async context =>
-                {
-                    await context.Response.WriteAsync("Hello World!");
-                });
-            });
+            app.UseDefaultFiles();
         }
     }
 }

--- a/app/Program.cs
+++ b/app/Program.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.AspNetCore.Http;
 
 namespace peachserver
 {
@@ -34,6 +35,8 @@ namespace peachserver
             services.AddWordPress(options =>
             {
                 //
+                options.SiteUrl = "http://localhost:5004/wordpress"; // Where the wordpress resides
+                options.HomeUrl = "http://localhost:5004"; // What url has the client site
             });
         }
 
@@ -49,7 +52,15 @@ namespace peachserver
             // using empty set of .NET plugins
             app.UseWordPress();
 
-            app.UseDefaultFiles();
+            app.UseRouting();
+            app.UseEndpoints(endpoints =>
+            {
+
+                endpoints.MapGet("/", async context =>
+                {
+                    await context.Response.WriteAsync("Hello World!");
+                });
+            });
         }
     }
 }

--- a/app/Program.cs
+++ b/app/Program.cs
@@ -34,8 +34,6 @@ namespace peachserver
             services.AddWordPress(options =>
             {
                 //
-                options.SiteUrl = "http://localhost:5004/wordpress";
-                options.HomeUrl = "http://localhost:5004";
             });
         }
 


### PR DESCRIPTION
Fix issue[#974](https://github.com/iolevel/wpdotnet-sdk/issues/106)

**Reason**

WordPress allows its installation into a subfolder. For this feature, `WP_SITE` refers to a WordPress installation folder, and `WP_HOME` refers to a path on the server containing a WordPress-generated website. Although wpdotnet-sdk distributes WordPress as an assembly, it needs similar functionality to enable the server to provide another web application( placed in a different path).

**Solution**

Rewritten the `UseWordPress` method respecting the `WP_SITE` and `WP_HOME` constants. It handles an incoming request when the requested URL contains either `WP_SITE` or `WP_HOME` URL as a subpath.

**Restriction**
Mentioned constants can also be stored in a database. They can be rewritten from the WordPress client. However, the constants defined in *config.php* (*appsettings.json*) have higher priority. This solution doesn't support obtaining the constants from the database.