### PR TITLE
Fix the issue

### DIFF
--- a/PeachPied.WordPress.Build.Plugin/build/Sdk.Common.props
+++ b/PeachPied.WordPress.Build.Plugin/build/Sdk.Common.props
@@ -2,6 +2,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 <Import Project="Sdk.props" Sdk="Peachpie.NET.Sdk" Version="1.0.6" />
 <PropertyGroup>
-<WpDotNetVersion Condition=" '$(WpDotNetVersion)'=='' ">5.8-preview10</WpDotNetVersion>
+<WpDotNetVersion Condition=" '$(WpDotNetVersion)'=='' ">5.8.0-preview10</WpDotNetVersion>
 </PropertyGroup>
 </Project>

--- a/PeachPied.WordPress.Build.Plugin/build/Sdk.Common.props
+++ b/PeachPied.WordPress.Build.Plugin/build/Sdk.Common.props
@@ -2,6 +2,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 <Import Project="Sdk.props" Sdk="Peachpie.NET.Sdk" Version="1.0.6" />
 <PropertyGroup>
-<WpDotNetVersion Condition=" '$(WpDotNetVersion)'=='' ">5.8.0-preview10</WpDotNetVersion>
+<WpDotNetVersion Condition=" '$(WpDotNetVersion)'=='' ">5.8-preview10</WpDotNetVersion>
 </PropertyGroup>
 </Project>

--- a/plugins/PeachPied.WordPress.HotPlug/FolderCompiler.cs
+++ b/plugins/PeachPied.WordPress.HotPlug/FolderCompiler.cs
@@ -12,7 +12,6 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading;
-using System.Text.RegularExpressions;
 
 namespace PeachPied.WordPress.HotPlug
 {

--- a/plugins/PeachPied.WordPress.HotPlug/FolderCompiler.cs
+++ b/plugins/PeachPied.WordPress.HotPlug/FolderCompiler.cs
@@ -109,16 +109,21 @@ namespace PeachPied.WordPress.HotPlug
                 return false;
             }
 
+            // a quick workaround
+            // lets compile the following only if there is `query-monitor` plugin
             if (fullpath.EndsWith("class-jetpack-search-debug-bar.php", StringComparison.InvariantCultureIgnoreCase))
             {
                 // (string pluginName) => { return pluginName == "jetpack" && !relativeFolderNames.Contains("query-monitor"); }}, //jetpack
+                return false;
             }
 
             if (fullpath.EndsWith("class-fs-debug-bar-panel.php", StringComparison.InvariantCultureIgnoreCase))
             {
                 // (string pluginName) => { return pluginName == "gutenslider" && !relativeFolderNames.Contains("query-monitor"); }}, //gutenslider
+                return false;
             }
 
+            //
             return true;
         }
 

--- a/plugins/PeachPied.WordPress.HotPlug/FolderCompiler.cs
+++ b/plugins/PeachPied.WordPress.HotPlug/FolderCompiler.cs
@@ -165,17 +165,20 @@ namespace PeachPied.WordPress.HotPlug
         string[] relativeFolderNames;
 
         /// <summary>
-        /// Excluded directories from the compilation.
+        /// Directories wildcards excluded from the compilation.
         /// </summary>
-        static Regex[] _excludeDirectories = new Regex[] {
-            new Regex($".*/tests(/.*)?$"),
-            new Regex($".*/test(/.*)?$"),
-            new Regex($".*/cli(/.*)?$"),
-            new Regex($".*/composer-php52(/.*)?$"),
-            new Regex($".*/cli(/.*)?$"),
-            new Regex($".*/jetpack-autoloader/src$"),
-            new Regex($".*/Composer/Installers$")
-        };
+        static readonly Regex[] s_excludeDirectories = new string[]
+        {
+            $".*/tests(/.*)?$",
+            $".*/test(/.*)?$",
+            $".*/cli(/.*)?$",
+            $".*/composer-php52(/.*)?$",
+            $".*/cli(/.*)?$",
+            $".*/jetpack-autoloader/src$",
+            $".*/Composer/Installers$",
+        }
+        .Select(regex => new Regex(regex, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled | RegexOptions.Singleline))
+        .ToArray();
 
         #endregion
 
@@ -405,7 +408,7 @@ namespace PeachPied.WordPress.HotPlug
         IReadOnlyCollection<string> CollectSourceFiles()
         { 
             return Directory.EnumerateDirectories(FullPath, "*", SearchOption.AllDirectories) // enumerate all directories
-            .Where(path => !_excludeDirectories.Any(dir => dir.IsMatch(path.Replace(Path.DirectorySeparatorChar,'/')))) // exclude someones
+            .Where(path => !s_excludeDirectories.Any(dir => dir.IsMatch(path.Replace(Path.DirectorySeparatorChar,'/')))) // exclude someones
             .SelectMany(dir => Directory.EnumerateFiles(dir, "*.php")) // enumerate files
             .Where(IsAllowedFile) // filter them
             .ToList();


### PR DESCRIPTION
fixes #115

**Problem**
Plugins like Jetpack or Gutenslider use *Debug_Bar_Panel* class, which is defined in Query Monitor plugin. The mentioned plugins do not have specified dependency on Query Monitor. For this reason, when the plugins are compiled, there is an undefined class error.

**Solution**
Added an extra logic to catch(manually) scripts(usually contain a definition of derived class from Debug_Bar_Panel) using *Debug_Bar_Panel* and exclude them, when there is not the necessary plugin.