### PR TITLE
Fix dictionary path separators

### DIFF
--- a/plugins/PeachPied.WordPress.HotPlug/FolderCompiler.cs
+++ b/plugins/PeachPied.WordPress.HotPlug/FolderCompiler.cs
@@ -279,7 +279,7 @@ namespace PeachPied.WordPress.HotPlug
 
                 _ignored = new HashSet<string>(
                     Directory
-                        .GetDirectories(Path.Combine(Compiler.RootPath, SubPath), "*", SearchOption.AllDirectories)
+                        .GetDirectories(FullPath, "*", SearchOption.AllDirectories)
                         .Where(d => Context.TryGetScriptsInDirectory(Compiler.RootPath, d, out _)),
                     StringComparer.InvariantCultureIgnoreCase);
             }

--- a/plugins/PeachPied.WordPress.HotPlug/HotPlug.cs
+++ b/plugins/PeachPied.WordPress.HotPlug/HotPlug.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
-using System.IO;
 
 namespace PeachPied.WordPress.HotPlug
 {
@@ -28,8 +27,8 @@ namespace PeachPied.WordPress.HotPlug
 
             _folders = new[]
             {
-                new FolderCompiler(compiler, $"wp-content{Path.DirectorySeparatorChar}plugins", "wp-plugins", logger),
-                new FolderCompiler(compiler, $"wp-content{Path.DirectorySeparatorChar}themes", "wp-themes", logger),
+                new FolderCompiler(compiler, "wp-content/plugins", "wp-plugins", logger),
+                new FolderCompiler(compiler, "wp-content/themes", "wp-themes", logger),
             };
         }
 


### PR DESCRIPTION
It causes re-compiling already compiled plugins due to not matching folder names with bad directory separators.  